### PR TITLE
Overwrite existing relative path (if any)

### DIFF
--- a/subcommands/set
+++ b/subcommands/set
@@ -19,7 +19,7 @@ dockerfile_path_set_cmd() {
   verify_app_name "$APP"
 
   [[ -z "$3" ]] && dokku_log_fail "Please specify the relative path to the Dockerfile used in the app $APP"
-  echo "$3" >> "$DOKKU_ROOT/$APP/DOCKERFILE_PATH"
+  echo "$3" > "$DOKKU_ROOT/$APP/DOCKERFILE_PATH"
   echo "Changed Dockerfile path"
 }
 


### PR DESCRIPTION
Instead of appending paths to those already in DOCKERFILE_PATH, each set operation should overwrite the content of DOCKERFILE_PATH.