### PR TITLE
Add report subcommand

### DIFF
--- a/commands
+++ b/commands
@@ -11,6 +11,7 @@ case "$1" in
       cat<<help_content
     dockerfile:set <app> <path/to/Dockerfile>, Set custom path to Dockerfile
     dockerfile:unset <app>, Unset custom path to Dockerfile
+    dockerfile:report <app>, Display custom path to Dockerfile for an app
 help_content
     }
 

--- a/commands
+++ b/commands
@@ -29,7 +29,7 @@ help_content
       help_content_func | sort | column -c2 -t -s,
     else
       cat<<help_desc
-    dockerfile, Plugin to manage alternative Dockerfile paths
+    dockerfile, Plugin for managing alternative Dockerfile paths
 help_desc
     fi
     ;;

--- a/plugin.toml
+++ b/plugin.toml
@@ -1,4 +1,4 @@
 [plugin]
 description = "dokku plugin to change the path to the dockerfile"
-version = "0.2.0"
+version = "0.3.0"
 [plugin.config]

--- a/plugin.toml
+++ b/plugin.toml
@@ -1,4 +1,4 @@
 [plugin]
-description = "dokku plugin to change the path to the dockerfile"
+description = "Build from a Dockerfile inside a subdirectory relative to the project root"
 version = "0.3.0"
 [plugin.config]

--- a/subcommands/report
+++ b/subcommands/report
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
+
+dockerfile_path_unset_cmd() {
+  #shellcheck disable=SC2034
+  declare desc="Report relative path to Dockerfile (if set)"
+  local cmd="dockerfile:report"
+  # Support --app/$DOKKU_APP_NAME flag
+  # Use the following lines to reorder args into "$cmd $DOKKU_APP_NAME $@""
+  local argv=("$@")
+  [[ ${argv[0]} == "$cmd" ]] && shift 1
+  [[ ! -z $DOKKU_APP_NAME ]] && set -- $DOKKU_APP_NAME $@
+  set -- $cmd $@
+  ##
+
+  APP="$2"
+  [[ -z "$APP" ]] && dokku_log_fail "Please specify an app to run the command on"
+  verify_app_name "$APP"
+
+  if [[ ! -e "$DOKKU_ROOT/$APP/DOCKERFILE_PATH" ]]; then
+          dokku_log_warn "No custom Dockerfile path was set for app $APP"
+  else
+      dokku_log_info1 "Dockerfile relative path for $APP is set to:"
+      dokku_log_info1 "$(cat $DOKKU_ROOT/$APP/DOCKERFILE_PATH)"
+  fi
+}
+
+dockerfile_path_unset_cmd "$@"

--- a/subcommands/set
+++ b/subcommands/set
@@ -20,7 +20,8 @@ dockerfile_path_set_cmd() {
 
   [[ -z "$3" ]] && dokku_log_fail "Please specify the relative path to the Dockerfile used in the app $APP"
   echo "$3" > "$DOKKU_ROOT/$APP/DOCKERFILE_PATH"
-  echo "Changed Dockerfile path"
+  dokku_log_info1 "Changed Dockerfile path for $APP to:"
+  dokku_log_info1 "$3"
 }
 
 dockerfile_path_set_cmd "$@"


### PR DESCRIPTION
This PR adds functionality to check whether the a custom path was set for any given app.

### Changelog
* `dockerfile:report <app>` should report the relative path to the Dockerfile, if a path is set.
* `dockerfile:set <app> <path>` will now report the path, after setting it.
* Updated plugin description.